### PR TITLE
Adding comment and link to doc about function from outside Apos core modules

### DIFF
--- a/lib/modules/artworks/index.js
+++ b/lib/modules/artworks/index.js
@@ -83,6 +83,8 @@ module.exports = {
     }
   ],
   construct: function (self, options) {
+    // Overriding importBeforeInsert from the apostrophe-pieces-import module.
+    // Doc: https://github.com/apostrophecms/apostrophe-pieces-import#extending-the-import-process-for-your-type
     self.importBeforeInsert = function (job, record, piece, callback) {
       // Have to force in joined Ids
       if (record.objectTypeId) {


### PR DESCRIPTION
We probably don't need comments like this everywhere in this codebase, but I had to look this one up, and since it wasn't in Apostrophe core looking it up wasn't totally trivial.

A comment like this seemed helpful in this case. Maybe the formatting or structure of my comment could be better? Feel free to edit.