### PR TITLE
optimize docker container build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+# ignore .git and .cache folders
+.git
+.cache
+
+npm-debug.log
+/public/uploads
+/public/apos-minified
+/data/temp/uploadfs
+node_modules
+# This folder is created on the fly and contains symlinks updated at startup (we'll come up with a Windows solution that actually copies things)
+/public/modules
+# We don't commit CSS, only LESS
+/public/css/*.css
+/public/css/*.map
+# Don't commit masters generated on the fly at startup, these import all the rest
+/public/css/master-*.less
+.jshintrc
+/public/js/_site-compiled.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,20 @@
+# Intall dependencies and copy application
+FROM node:carbon as builder
+
+# Install dependencies only
+# Will only run npm install when dependencies changes
+COPY package.json package-lock.json /app/
+RUN cd /app/ && npm install
+
+# Copy app
+COPY . /app/
+
+# Build final cointainer
 FROM node:carbon
 
-# Create app directory
-RUN mkdir -p /app
+# Copy app from previous stage
+COPY --from=builder /app /app
 WORKDIR /app
-
-# Bundle app source
-COPY . /app
-RUN npm install
-
 # Mount persistent storage
 VOLUME /app/data
 VOLUME /app/public/uploads


### PR DESCRIPTION
This MR add a `.dockerignore` file to avoid copying unwanted files and optimize the Docker build process.

Having `npm install` dissociated from the app copy step will allow docker to properly cache the dependencies when both `package.json` and `package-lock.json` haven't changed.

Splitting the Docker build in two phases will reduce the number of layers in the final Docker image.

Overall, the new Docker image weight 412.30 MiB instead of 503.26 MiB.

I'm pushing this as I'm using your new demo to build k8s/helm optimized setups for apostrophe.