### PR TITLE
Removes the columns widget from inside the columns widget areas

### DIFF
--- a/lib/modules/columns-widgets/index.js
+++ b/lib/modules/columns-widgets/index.js
@@ -1,5 +1,8 @@
 const _ = require('lodash');
-const areas = require('../helpers/lib/areas.js');
+const {baseWidgets} = require('../helpers/lib/areas.js');
+
+const columnWidgets = _.cloneDeep(baseWidgets);
+delete columnWidgets.columns;
 
 module.exports = {
   label: 'Columns',
@@ -31,7 +34,7 @@ module.exports = {
       contextual: true,
       type: 'area',
       options: {
-        widgets: _.cloneDeep(areas.baseWidgets)
+        widgets: columnWidgets
       }
     },
     {
@@ -40,7 +43,7 @@ module.exports = {
       contextual: true,
       type: 'area',
       options: {
-        widgets: _.cloneDeep(areas.baseWidgets)
+        widgets: columnWidgets
       }
     },
     {
@@ -49,7 +52,7 @@ module.exports = {
       contextual: true,
       type: 'area',
       options: {
-        widgets: _.cloneDeep(areas.baseWidgets)
+        widgets: columnWidgets
       }
     }
   ]


### PR DESCRIPTION
It's possible that was intentional, but it seemed potentially messy to have columns inside columns forever.