### PR TITLE
Update _tag-picker.less

### DIFF
--- a/lib/modules/apostrophe-assets/public/css/components/_tag-picker.less
+++ b/lib/modules/apostrophe-assets/public/css/components/_tag-picker.less
@@ -3,7 +3,7 @@
 }
 
 .c-tag-picker__tags {
-  min-width: 45rem;
+  min-width: 20rem;
 }
 
 .c-tag-picker__display {


### PR DESCRIPTION
change the min-width of tag picker so it loads properly on mobile (45 rem exceeds mobile width screen, creating extra white space)